### PR TITLE
chore: add org reusable CI for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  docs:
+    name: Documentation Checks
+    uses: mca-nitw/.github/.github/workflows/markdown-check.yml@main
+    with:
+      glob: "**/*.md"
+      check-links: true
+
+  security:
+    name: Security Scan
+    uses: mca-nitw/.github/.github/workflows/security-scan.yml@main
+    permissions:
+      contents: read
+      security-events: write

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,26 @@
+# Markdownlint config — relaxed for academic notes which contain
+# heavy formula/code/list nesting and may not need strict prose linting.
+
+default: true
+
+# Allow long lines (notes often quote long URLs / formulas)
+MD013: false
+
+# Allow inline HTML (used for tables, embedded SVG/images)
+MD033: false
+
+# Don't require unique top-level headings (per-section notes can repeat)
+MD025: false
+
+# Allow duplicate heading text (common for "Examples" / "Summary" sections)
+MD024:
+  siblings_only: true
+
+# Don't require trailing newline (auto-fixed elsewhere)
+MD047: false
+
+# Trailing punctuation in headings is fine for academic notes
+MD026: false
+
+# Allow no language tag on fenced code (math/pseudocode often)
+MD040: false

--- a/renovate.json
+++ b/renovate.json
@@ -1,40 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"],
-  "timezone": "Asia/Kolkata",
-  "schedule": ["before 3am on monday"],
-  "prHourlyLimit": 2,
-  "prConcurrentLimit": 3,
-  "rangeStrategy": "replace",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash",
-      "groupName": "non-major weekly",
-      "labels": ["dependencies", "auto-merge"]
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "groupName": "major updates",
-      "labels": ["dependencies", "major"],
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchDatasources": ["docker"],
-      "groupName": "docker",
-      "schedule": ["before 3am on monday"]
-    },
-    {
-      "matchCategories": ["lock-file-maintenance"],
-      "schedule": ["before 3am on monday"],
-      "automerge": true
-    }
-  ],
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["security"],
-    "schedule": ["at any time"]
-  }
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["github>mca-nitw/.github"]
 }


### PR DESCRIPTION
Follow-up to MCA-NITW/.github#9.

Adds CI to a previously CI-free docs repo. Two checks now run on every PR: markdown linting + dead-link check, and security scan. Markdownlint config is relaxed (academic notes have long lines, embedded math, varying heading patterns).